### PR TITLE
Deprecate DBot :sad:

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A Slack bot to add security info to messages containing URLs, hashes and IPs. You can see it in action at [dbot.demisto.com](https://dbot.demisto.com).
 
+## Deprecation Notice
+DBot has been deprecated and is no longer supported by the Demisto team.
+
 ## Authors
 This project was built by the [Demisto](https://www.demisto.com) team
 


### PR DESCRIPTION
Truly a sad day for the Demisto family.

Dee Bot (DBot) has deprecated peacefully in its sleep after a long struggle with acquisition at the age of 7. DBot was born June 22nd, 2015 in Santa Clara, CA to the proud parents @rishibhargava and @slavikm where it brought about an industry-wide change to SOC automation and threat management.

"DBot is the reason I stuck around all these years" - Queen Elizabeth
"Through thick and thin, DBot was always a friend" - Bill Gates
"In the early 80s, DBot inspired me to write the hit _I'm Still Standing_" - Elton John

 Services will be held in on DFIR.